### PR TITLE
Fix RconFtpServer#file_count_per_thread spec

### DIFF
--- a/spec/models/rcon_ftp_server_spec.rb
+++ b/spec/models/rcon_ftp_server_spec.rb
@@ -208,7 +208,7 @@ describe RconFtpServer do
 
     it "calculates how many files each thread should get to meet the connection limit" do
       files = 1.upto(100).to_a
-      subject.file_count_per_thread(files).should eql 10
+      subject.file_count_per_thread(files).should eql 25
     end
 
   end


### PR DESCRIPTION
Spec fails because of 0422c36, which lowered the FTP connection pool size from 10 to 4.