### PR TITLE
FAQ and Server-Providers updated

### DIFF
--- a/app/views/pages/faq.html.haml
+++ b/app/views/pages/faq.html.haml
@@ -87,14 +87,6 @@
 
     .well
       %p.text-success
-        Q: How can I enable sv_cheats?
-      %p
-        %em
-          A: The TFTrue plugin enforces some competitive settings, but you can override this:
-          rcon tftrue_tournament_insecure 1; rcon sv_cheats 1
-
-    .well
-      %p.text-success
         Q: What maps are there?
       %p
         %em

--- a/app/views/pages/server_providers.html.haml
+++ b/app/views/pages/server_providers.html.haml
@@ -60,12 +60,9 @@
         %td= link_to('slate', 'http://etf2l.org/forum/user/11427/',     :target => '_blank')
         %td
           %p
-            slate is an
-            = link_to('ETF2L', 'http://etf2l.org',                      :target => '_blank')
-            site coder and
+            slate a
             = link_to('Trick17', 'http://etf2l.org/teams/8897/', :target => '_blank')
-            member.
-            slate provides a bunch of gameservers.
+            member and provides a bunch of gameservers.
         %td Germany, Frankfurt
         %td srv.trick17.eu
 


### PR DESCRIPTION
tftrue_tournament_insecure cvar doesn't exist anymore as of TFTrue
Version 4.2 ( November 3, 2013 ).

Updated info on the Server-Providers page.