### PR TITLE
"!who" command and related F&Q update

### DIFF
--- a/app/views/pages/faq.html.haml
+++ b/app/views/pages/faq.html.haml
@@ -79,6 +79,43 @@
 
     .well
       %p.text-success
+        Q: What commands are available inside the server chat?
+      %p
+        %em
+          A: If you are the one that has reserved the server. Here are some handy commands you can use from within the server chat:
+          %table.table
+            %tr
+              %td
+                !rcon
+              %td
+                This runs whatever you placed after the cmd (with a space as rcon) for example you can run "```!rcon changelevel koth_product```" to change the map on the server to koth_product
+            %tr
+              %td
+                !extend
+              %td
+                Extends the time of the reservation by 1 hour. However this will only work if the server is free to reserve.
+            %tr
+              %td
+                !end
+              %td
+                Ends the reservation and kicks all players
+        %p
+          %em
+          These commands are available to everyone:
+          %table.table
+            %tr
+              %td
+                !who
+              %td
+                Returns the name of the user that reserved the server
+            %tr
+              %td
+                !timeleft
+              %td
+                Lists the number of minutes left in the reservation
+
+    .well
+      %p.text-success
         Q: How do I change the map?
       %p
         %em

--- a/app/workers/log_worker.rb
+++ b/app/workers/log_worker.rb
@@ -9,6 +9,7 @@ class LogWorker
   EXTEND_COMMAND    = /!extend.*/
   RCON_COMMAND      = /!rcon.*/
   TIMELEFT_COMMAND  = /!timeleft.*/
+  WHOIS_RESERVER    = /!who.*/
   LOG_LINE_REGEX    = '(?\'secret\'\d*)(?\'line\'.*)'
 
   def perform(raw_line)
@@ -75,6 +76,10 @@ class LogWorker
     reservation.server.rcon_say "Reservation time left: #{timeleft}"
   end
 
+  def handle_whois_reserver
+    reservation.server.rcon_say "Reservation created by: '#{reserver.name}'"
+  end
+
   def action_for_message_said_by_reserver
     case message
     when END_COMMAND
@@ -90,6 +95,8 @@ class LogWorker
     case message
     when TIMELEFT_COMMAND
       :handle_timeleft
+    when WHOIS_RESERVER
+      :handle_whois_reserver
     end
   end
 

--- a/spec/workers/log_worker_spec.rb
+++ b/spec/workers/log_worker_spec.rb
@@ -13,6 +13,7 @@ describe LogWorker do
   let(:rcon_empty_line)       { '1234567L 03/29/2014 - 13:15:53: "Arie - serveme.tf<3><[U:1:231702]><Red>" say "!rcon"' }
   let(:rcon_with_quotes_line) { '1234567L 03/29/2014 - 13:15:53: "Arie - serveme.tf<3><[U:1:231702]><Red>" say "!rcon mp_tournament "1""' }
   let(:timeleft_line)         { '1234567L 03/29/2014 - 13:15:53: "Troll<3><[U:1:12345]><Red>" say "!timeleft"' }
+  let(:who_line)              { '1234567L 03/29/2014 - 13:15:53: "Troll<3><[U:1:12345]><Red>" say "!who"' }
   let(:turbine_start_line)    { '1234567L 02/07/2015 - 20:39:40: Started map "ctf_turbine" (CRC "a7e226a1ff6dd4b8d546d7d341d446dc")' }
   let(:badlands_start_line)   { '1234567L 02/07/2015 - 20:39:40: Started map "cp_badlands" (CRC "a7e226a1ff6dd4b8d546d7d341d446dc")' }
   subject(:logworker) { LogWorker.perform_async(line) }
@@ -99,6 +100,15 @@ describe LogWorker do
     it "returns the time left in words for the reservation" do
       server.should_receive(:rcon_say).with(/Reservation time left: \d+ minutes/)
       LogWorker.perform_async(timeleft_line)
+    end
+
+  end
+
+  describe "who" do
+
+    it "returns the name of the reserver for the reservation" do
+      server.should_receive(:rcon_say).with("Reservation created by: #{reservation.user.name}")
+      LogWorker.perform_async(who_line)
     end
 
   end

--- a/spec/workers/log_worker_spec.rb
+++ b/spec/workers/log_worker_spec.rb
@@ -107,7 +107,7 @@ describe LogWorker do
   describe "who" do
 
     it "returns the name of the reserver for the reservation" do
-      server.should_receive(:rcon_say).with("Reservation created by: #{reservation.user.name}")
+      server.should_receive(:rcon_say).with("Reservation created by: '#{reservation.user.name}'")
       LogWorker.perform_async(who_line)
     end
 


### PR DESCRIPTION
#### Created a "!who" command that should return the reserver name in chat.
Currently users have to exit the game to find this information on servme.tf. 
This is important as reservers might not be paying attention the the chat warning of a resvation timeout or even in the current game. This gives players a fighting chance to pm them or use in game voice

####  Added F&Q section listing in game commands
