### PR TITLE
Require !who to be an exact match

### DIFF
--- a/app/workers/log_worker.rb
+++ b/app/workers/log_worker.rb
@@ -9,7 +9,7 @@ class LogWorker
   EXTEND_COMMAND    = /!extend.*/
   RCON_COMMAND      = /!rcon.*/
   TIMELEFT_COMMAND  = /!timeleft.*/
-  WHOIS_RESERVER    = /!who.*/
+  WHOIS_RESERVER    = /^!who$/
   LOG_LINE_REGEX    = '(?\'secret\'\d*)(?\'line\'.*)'
 
   def perform(raw_line)

--- a/spec/workers/log_worker_spec.rb
+++ b/spec/workers/log_worker_spec.rb
@@ -120,7 +120,7 @@ describe LogWorker do
       LogWorker.perform_async(who_line)
     end
     
-    it "should not return if there is text before or afterthe command" do
+    it "should not return if there is text before or after the command" do
       server.should_not_receive(:rcon_say)
       ReservationWorker.should_not_receive(:perform_async).with("Reservation created by: '#{reservation.user.name}'")
       LogWorker.perform_async(who_troll)

--- a/spec/workers/log_worker_spec.rb
+++ b/spec/workers/log_worker_spec.rb
@@ -15,6 +15,7 @@ describe LogWorker do
   let(:rcon_with_quotes_line) { '1234567L 03/29/2014 - 13:15:53: "Arie - serveme.tf<3><[U:1:231702]><Red>" say "!rcon mp_tournament "1""' }
   let(:timeleft_line)         { '1234567L 03/29/2014 - 13:15:53: "Troll<3><[U:1:12345]><Red>" say "!timeleft"' }
   let(:who_line)              { '1234567L 03/29/2014 - 13:15:53: "Troll<3><[U:1:12345]><Red>" say "!who"' }
+  let(:who_troll)             { '1234567L 03/29/2014 - 19:15:53: "BindTroll<3><[U:1:12344]><Red>" say "!who is the best"' }
   let(:turbine_start_line)    { '1234567L 02/07/2015 - 20:39:40: Started map "ctf_turbine" (CRC "a7e226a1ff6dd4b8d546d7d341d446dc")' }
   let(:badlands_start_line)   { '1234567L 02/07/2015 - 20:39:40: Started map "cp_badlands" (CRC "a7e226a1ff6dd4b8d546d7d341d446dc")' }
   subject(:logworker) { LogWorker.perform_async(line) }
@@ -117,6 +118,12 @@ describe LogWorker do
     it "returns the name of the reserver for the reservation" do
       server.should_receive(:rcon_say).with("Reservation created by: '#{reservation.user.name}'")
       LogWorker.perform_async(who_line)
+    end
+    
+    it "should not return if there is text before or afterthe command" do
+      server.should_not_receive(:rcon_say)
+      ReservationWorker.should_not_receive(:perform_async).with("Reservation created by: '#{reservation.user.name}'")
+      LogWorker.perform_async(who_troll)
     end
 
   end


### PR DESCRIPTION
A perhaps unintended consequence of allowing the !who command to have symbols after is that some users are using it to point to the server reserver.

This works nicely with binds such as:
- !who needs to CHANGE THE CONFIG???
 
But ofcourse there is a lot more negative use of it:
- !whore
- !whois gay
- !who is not getting an uber
- !who is shit at mge

This pull request is to force an exact match.

