### PR TITLE
Update the end time to 2 hours after start time on change

### DIFF
--- a/app/assets/javascripts/reservation.js.erb
+++ b/app/assets/javascripts/reservation.js.erb
@@ -161,6 +161,16 @@ $(document).ready(function() {
   }
 
   $("#reservation_starts_at").change(function() {
+
+    startDate = getDateFromDatePicker($(this));
+    endDate = getDateFromDatePicker($("#reservation_ends_at"));
+
+    if(endDate < startDate){
+      newDate = new Date(startDate.getTime() + 7200000);
+      $("#reservation_ends_at").datetimepicker("setUTCDate", newDate)
+    }
+    $("#reservation_ends_at").datetimepicker("setStartDate", $(this).val())
+
     findFreeServers();
   });
 
@@ -213,6 +223,15 @@ $(document).ready(function() {
         }
       })
   });
+
+  function getDateFromDatePicker(element){
+    return $.fn.datetimepicker.DPGlobal.parseDate(
+      element.val(),
+      $.fn.datetimepicker.DPGlobal.parseFormat(datepicker_options.format, 'standard'),
+      "en",
+      'standard'
+    );
+  }
 
   function updateStartsAt() {
     startsAt().change();


### PR DESCRIPTION
Currently this uses the internal workings of the datepicker plugin, should later more localisation besides english be added, you will need to add that in the getDateFromDatePicker function.

Current behavior:

If you change the start date, and now the end date is before the start date, the end date gets updated to start date + 2 hours.