### PR TITLE
fix: removed 1px shift of all elements on hover over certain navbar elements

### DIFF
--- a/app/assets/stylesheets/_navigation.sass
+++ b/app/assets/stylesheets/_navigation.sass
@@ -10,8 +10,6 @@
     .nav-link
       padding-left: 0.75rem
       padding-right: 0.75rem
-      &:hover
-        border-bottom: 1px solid #17191b
     .nav-item.dropdown
       .nav-link
         &:hover


### PR DESCRIPTION
As it says on the can. If you moved your mouse over Reservations and then to Servers, a 1 pixel border was added to the bottom of the anchor tag for the navlink item (which is any non-dropdown link in the navbar)

This 1 pixel border would subsequently push all elements lower on the page by 1 pixel.

It's really a non-issue, but it annoyed me, so I decided to correct it.

Removing this 1 pixel border does not appear to impose any regressions or unforeseen consequences.